### PR TITLE
Fixed small bug with h5py >=3.0

### DIFF
--- a/synchrad/calc.py
+++ b/synchrad/calc.py
@@ -631,5 +631,9 @@ class SynchRad(Utilities):
                 for key in f['Args'].keys():
                     self.Args[key] = f['Args/'+key][()]
 
+                    # in h5py >=3.0, the strings in datasets are bytes!
+                    if isinstance(self.Args[key], bytes):
+                        self.Args[key] = self.Args[key].decode()
+
                 self.snap_iterations = f['snap_iterations'][()]
                 self.total_weight = f['total_weight'][()]


### PR DESCRIPTION
With h5py version >=3.0, the strings saved as datasets are read in as bytes objects. This meant the Args dict contained some bytes objects, which broke the analysis tools. This small fix checks for bytes objects and decodes them as the data is read in from saved files.