### PR TITLE
Fix t glob

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,11 +10,9 @@ import synchrad
 # Obtain the long description from README.md
 # If possible, use pypandoc to convert the README from Markdown
 # to reStructuredText, as this is the only supported format on PyPI
-try:
-    import pypandoc
-    long_description = pypandoc.convert( './README.md', 'rst')
-except (ImportError, RuntimeError):
-    long_description = open('./README.md').read()
+with open("./README.md", encoding="utf-8") as f:
+     long_description = f.read()
+
 # Get the package requirements from the requirements.txt file
 with open('requirements.txt') as f:
     install_requires = [ line.strip('\n') for line in f.readlines() ]

--- a/synchrad/__init__.py
+++ b/synchrad/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.0.2'
+__version__ = '0.0.3'
 __doc__ = """
 synchrad
 """

--- a/synchrad/calc.py
+++ b/synchrad/calc.py
@@ -99,7 +99,7 @@ class SynchRad(Utilities):
     def calculate_spectrum(self, particleTracks=[], file_tracks=None,
                            timeStep=None, comp='total', L_screen=None,
                            Np_max=None, it_range=None,
-                           nSnaps=1, sigma_particle=0,
+                           nSnaps=1, sigma_particle=0, weights_to_unity=False,
                            file_spectrum=None,
                            verbose=True):
         """
@@ -235,6 +235,8 @@ class SynchRad(Utilities):
 
         for itr in calc_iterator:
             track = particleTracks[itr]
+            if weights_to_unity:
+                track[6] = 1.0
             self.total_weight += track[6]
             track = self._track_to_device(track)
             self._process_track(track, comp, nSnaps, it_range)

--- a/synchrad/kernel_farfield.cl
+++ b/synchrad/kernel_farfield.cl
@@ -273,7 +273,7 @@ __kernel void cartesian_comps_complex(
     ${my_dtype} time, phase, dPhase, sinPhase, cosPhase, c1, c2, gammaInv;
 
     ${my_dtype} dtInv = (${my_dtype})1. / dt;
-    ${my_dtype} wpdt = ${f_native}sqrt(wp) * dt;
+    ${my_dtype} wpdt = wp * dt;
     ${my_dtype} phasePrev = (${my_dtype}) 0.;
     ${my_dtype}3 spectrLocalRe = (${my_dtype}3) {0., 0., 0.};
     ${my_dtype}3 spectrLocalIm = (${my_dtype}3) {0., 0., 0.};
@@ -520,7 +520,7 @@ __kernel void spheric_comps_complex(
     ${my_dtype} time, phase, dPhase, sinPhase, cosPhase, c1, c2, gammaInv;
 
     ${my_dtype} dtInv = (${my_dtype})1. / dt;
-    ${my_dtype} wpdt =  ${f_native}sqrt(wp) * dt;
+    ${my_dtype} wpdt =  wp * dt;
     ${my_dtype} phasePrev = (${my_dtype}) 0.;
     ${my_dtype}3 spectrLocalRe = (${my_dtype}3) {0., 0., 0.};
     ${my_dtype}3 spectrLocalIm = (${my_dtype}3) {0., 0., 0.};

--- a/synchrad/kernel_farfield.cl
+++ b/synchrad/kernel_farfield.cl
@@ -62,7 +62,7 @@ __kernel void total(
 
       if (it<nSteps-1)
       {
-        time = (${my_dtype})it * dt;
+        time = (${my_dtype})it_glob * dt;
         xLocal = (${my_dtype}3) {x[it], y[it], z[it]};
 
         phase = omegaLocal * (time - dot(xLocal, nVec)) ;
@@ -169,7 +169,7 @@ __kernel void cartesian_comps(
 
       if (it<nSteps-1)
       {
-        time = (${my_dtype})it * dt;
+        time = (${my_dtype})it_glob * dt;
         xLocal = (${my_dtype}3) {x[it], y[it], z[it]};
 
         phase = omegaLocal * (time - dot(xLocal, nVec)) ;
@@ -273,7 +273,7 @@ __kernel void cartesian_comps_complex(
     ${my_dtype} time, phase, dPhase, sinPhase, cosPhase, c1, c2, gammaInv;
 
     ${my_dtype} dtInv = (${my_dtype})1. / dt;
-    ${my_dtype} wpdt =  wp * dt;
+    ${my_dtype} wpdt = ${f_native}sqrt(wp) * dt;
     ${my_dtype} phasePrev = (${my_dtype}) 0.;
     ${my_dtype}3 spectrLocalRe = (${my_dtype}3) {0., 0., 0.};
     ${my_dtype}3 spectrLocalIm = (${my_dtype}3) {0., 0., 0.};
@@ -290,7 +290,7 @@ __kernel void cartesian_comps_complex(
 
       if (it<nSteps-1)
       {
-        time = (${my_dtype})it * dt;
+        time = (${my_dtype})it_glob * dt;
         xLocal = (${my_dtype}3) {x[it], y[it], z[it]};
 
         phase = omegaLocal * (time - dot(xLocal, nVec)) ;
@@ -408,7 +408,7 @@ __kernel void spheric_comps(
 
       if (it<nSteps-1)
       {
-        time = (${my_dtype})it * dt;
+        time = (${my_dtype})it_glob * dt;
         xLocal = (${my_dtype}3) {x[it], y[it], z[it]};
 
         phase = omegaLocal * (time - dot(xLocal, nVec)) ;
@@ -520,7 +520,7 @@ __kernel void spheric_comps_complex(
     ${my_dtype} time, phase, dPhase, sinPhase, cosPhase, c1, c2, gammaInv;
 
     ${my_dtype} dtInv = (${my_dtype})1. / dt;
-    ${my_dtype} wpdt =  wp * dt;
+    ${my_dtype} wpdt =  ${f_native}sqrt(wp) * dt;
     ${my_dtype} phasePrev = (${my_dtype}) 0.;
     ${my_dtype}3 spectrLocalRe = (${my_dtype}3) {0., 0., 0.};
     ${my_dtype}3 spectrLocalIm = (${my_dtype}3) {0., 0., 0.};
@@ -537,7 +537,7 @@ __kernel void spheric_comps_complex(
 
       if (it<nSteps-1)
       {
-        time = (${my_dtype})it * dt;
+        time = (${my_dtype})it_glob * dt;
         xLocal = (${my_dtype}3) {x[it], y[it], z[it]};
 
         phase = omegaLocal * (time - dot(xLocal, nVec)) ;

--- a/synchrad/kernel_farfield.cl
+++ b/synchrad/kernel_farfield.cl
@@ -273,7 +273,7 @@ __kernel void cartesian_comps_complex(
     ${my_dtype} time, phase, dPhase, sinPhase, cosPhase, c1, c2, gammaInv;
 
     ${my_dtype} dtInv = (${my_dtype})1. / dt;
-    ${my_dtype} wpdt = wp * dt;
+    ${my_dtype} wpdt = ${f_native}sqrt(wp) * dt;
     ${my_dtype} phasePrev = (${my_dtype}) 0.;
     ${my_dtype}3 spectrLocalRe = (${my_dtype}3) {0., 0., 0.};
     ${my_dtype}3 spectrLocalIm = (${my_dtype}3) {0., 0., 0.};
@@ -520,7 +520,7 @@ __kernel void spheric_comps_complex(
     ${my_dtype} time, phase, dPhase, sinPhase, cosPhase, c1, c2, gammaInv;
 
     ${my_dtype} dtInv = (${my_dtype})1. / dt;
-    ${my_dtype} wpdt =  wp * dt;
+    ${my_dtype} wpdt =  ${f_native}sqrt(wp) * dt;
     ${my_dtype} phasePrev = (${my_dtype}) 0.;
     ${my_dtype}3 spectrLocalRe = (${my_dtype}3) {0., 0., 0.};
     ${my_dtype}3 spectrLocalIm = (${my_dtype}3) {0., 0., 0.};

--- a/synchrad/kernel_nearfield.cl
+++ b/synchrad/kernel_nearfield.cl
@@ -261,7 +261,7 @@ __kernel void cartesian_comps_complex(
     ${my_dtype}3 xLocal, uLocal, rVec, nVec, c1, c2;
     ${my_dtype} time, phase, dPhase, sinPhase, cosPhase, rLocal, rInv, gammaInv;
 
-    ${my_dtype} wpdt =  ${f_native}sqrt(wp) * dt;
+    ${my_dtype} wpdt = wp * dt;
     ${my_dtype} phasePrev = (${my_dtype}) 0.;
     ${my_dtype}3 spectrLocalRe = (${my_dtype}3) {0., 0., 0.};
     ${my_dtype}3 spectrLocalIm = (${my_dtype}3) {0., 0., 0.};

--- a/synchrad/kernel_nearfield.cl
+++ b/synchrad/kernel_nearfield.cl
@@ -61,7 +61,7 @@ __kernel void total(
 
       if (it<nSteps-1)
       {
-        time = (${my_dtype})it * dt;
+        time = (${my_dtype})it_glob * dt;
         xLocal = (${my_dtype}3) {x[it], y[it], z[it]};
 
         rVec = coordOnScreen - xLocal;
@@ -164,7 +164,7 @@ __kernel void cartesian_comps(
 
       if (it<nSteps-1)
       {
-        time = (${my_dtype})it * dt;
+        time = (${my_dtype})it_glob * dt;
         xLocal = (${my_dtype}3) {x[it], y[it], z[it]};
 
         rVec = coordOnScreen - xLocal;
@@ -261,7 +261,7 @@ __kernel void cartesian_comps_complex(
     ${my_dtype}3 xLocal, uLocal, rVec, nVec, c1, c2;
     ${my_dtype} time, phase, dPhase, sinPhase, cosPhase, rLocal, rInv, gammaInv;
 
-    ${my_dtype} wpdt =  wp * dt;
+    ${my_dtype} wpdt =  ${f_native}sqrt(wp) * dt;
     ${my_dtype} phasePrev = (${my_dtype}) 0.;
     ${my_dtype}3 spectrLocalRe = (${my_dtype}3) {0., 0., 0.};
     ${my_dtype}3 spectrLocalIm = (${my_dtype}3) {0., 0., 0.};
@@ -278,7 +278,7 @@ __kernel void cartesian_comps_complex(
 
       if (it<nSteps-1)
       {
-        time = (${my_dtype})it * dt;
+        time = (${my_dtype})it_glob * dt;
         xLocal = (${my_dtype}3) {x[it], y[it], z[it]};
 
         rVec = coordOnScreen - xLocal;

--- a/synchrad/kernel_nearfield.cl
+++ b/synchrad/kernel_nearfield.cl
@@ -261,7 +261,7 @@ __kernel void cartesian_comps_complex(
     ${my_dtype}3 xLocal, uLocal, rVec, nVec, c1, c2;
     ${my_dtype} time, phase, dPhase, sinPhase, cosPhase, rLocal, rInv, gammaInv;
 
-    ${my_dtype} wpdt = wp * dt;
+    ${my_dtype} wpdt = ${f_native}sqrt(wp) * dt;
     ${my_dtype} phasePrev = (${my_dtype}) 0.;
     ${my_dtype}3 spectrLocalRe = (${my_dtype}3) {0., 0., 0.};
     ${my_dtype}3 spectrLocalIm = (${my_dtype}3) {0., 0., 0.};


### PR DESCRIPTION
This PR fixes the bug with physical time axis -- previously the track with different starting iteration had different local time axes which lead to problems with coherent mappers. Currently the global time axis is used for all tracks.
Also have added an option to replace particle weights with `1` for a more physical consideration of coherent effects. This should at least partially address the problem presented in #23 