### PR TITLE
Fix dimensional mismatching between z and t in tracksfromOPMD

### DIFF
--- a/synchrad/converters.py
+++ b/synchrad/converters.py
@@ -91,10 +91,11 @@ def tracksFromOPMD(ts, pt, ref_iteration,
     f = h5py.File(fname, mode='w')
 
     for ip in range(pt.N_selected):
-        track_pieces = split_track_by_nans(
+        t=ts.t.copy()
+        track_pieces, good_inds = split_track_by_nans(
                 TC['x'][ip], TC['y'][ip], TC['z'][ip],
                 TC['ux'][ip], TC['uy'][ip], TC['uz'][ip], TC['w'][ip])
-
+        t=t[good_inds]
         for track in track_pieces:
             x, y, z, ux, uy, uz, w, it_start = track
             nsteps = x.size
@@ -304,6 +305,7 @@ def split_track_by_nans(x, y, z, ux, uy, uz, w):
     uz_loc = []
     w_loc = []
     iterations_loc = []
+    good_inds = [] # The indices for which the value is not nan
     TrackRecorded = False
 
     for it, val in enumerate(w):
@@ -317,6 +319,7 @@ def split_track_by_nans(x, y, z, ux, uy, uz, w):
             uz_loc.append(uz[it])
             w_loc.append(w[it])
             iterations_loc.append(it)
+            good_inds.append(it)
         else:
             trackContainer.append([
                 np.array(x_loc), np.array(y_loc), np.array(z_loc),
@@ -348,7 +351,7 @@ def split_track_by_nans(x, y, z, ux, uy, uz, w):
             trackContainerSelected.append( [x_loc, y_loc, z_loc, \
                                       ux_loc, uy_loc, uz_loc, \
                                       w_loc[0], iterations_loc[0]])
-    return trackContainerSelected
+    return trackContainerSelected, good_inds
 
 @njit
 def record_particles_step(tracks, nsteps, it, it_start,

--- a/synchrad/converters.py
+++ b/synchrad/converters.py
@@ -92,10 +92,9 @@ def tracksFromOPMD(ts, pt, ref_iteration,
 
     for ip in range(pt.N_selected):
         t=ts.t.copy()
-        track_pieces, good_inds = split_track_by_nans(
+        track_pieces = split_track_by_nans(
                 TC['x'][ip], TC['y'][ip], TC['z'][ip],
                 TC['ux'][ip], TC['uy'][ip], TC['uz'][ip], TC['w'][ip])
-        t=t[good_inds]
         for track in track_pieces:
             x, y, z, ux, uy, uz, w, it_start = track
             nsteps = x.size
@@ -103,7 +102,7 @@ def tracksFromOPMD(ts, pt, ref_iteration,
                 f[f'tracks/{i_tr:d}/x'] = x
                 f[f'tracks/{i_tr:d}/y'] = y
                 if z_is_xi:
-                    f[f'tracks/{i_tr:d}/z'] = z + c * t
+                    f[f'tracks/{i_tr:d}/z'] = z + c * t[it_start:it_start+z.size]
                 else:
                     f[f'tracks/{i_tr:d}/z'] = z
                 f[f'tracks/{i_tr:d}/ux'] = ux
@@ -305,7 +304,6 @@ def split_track_by_nans(x, y, z, ux, uy, uz, w):
     uz_loc = []
     w_loc = []
     iterations_loc = []
-    good_inds = [] # The indices for which the value is not nan
     TrackRecorded = False
 
     for it, val in enumerate(w):
@@ -319,7 +317,6 @@ def split_track_by_nans(x, y, z, ux, uy, uz, w):
             uz_loc.append(uz[it])
             w_loc.append(w[it])
             iterations_loc.append(it)
-            good_inds.append(it)
         else:
             trackContainer.append([
                 np.array(x_loc), np.array(y_loc), np.array(z_loc),
@@ -351,7 +348,7 @@ def split_track_by_nans(x, y, z, ux, uy, uz, w):
             trackContainerSelected.append( [x_loc, y_loc, z_loc, \
                                       ux_loc, uy_loc, uz_loc, \
                                       w_loc[0], iterations_loc[0]])
-    return trackContainerSelected, good_inds
+    return trackContainerSelected
 
 @njit
 def record_particles_step(tracks, nsteps, it, it_start,

--- a/synchrad/converters.py
+++ b/synchrad/converters.py
@@ -91,10 +91,10 @@ def tracksFromOPMD(ts, pt, ref_iteration,
     f = h5py.File(fname, mode='w')
 
     for ip in range(pt.N_selected):
-        t=ts.t.copy()
         track_pieces = split_track_by_nans(
                 TC['x'][ip], TC['y'][ip], TC['z'][ip],
                 TC['ux'][ip], TC['uy'][ip], TC['uz'][ip], TC['w'][ip])
+
         for track in track_pieces:
             x, y, z, ux, uy, uz, w, it_start = track
             nsteps = x.size
@@ -102,7 +102,7 @@ def tracksFromOPMD(ts, pt, ref_iteration,
                 f[f'tracks/{i_tr:d}/x'] = x
                 f[f'tracks/{i_tr:d}/y'] = y
                 if z_is_xi:
-                    f[f'tracks/{i_tr:d}/z'] = z + c * t[it_start:it_start+z.size]
+                    f[f'tracks/{i_tr:d}/z'] = z + c * t[it_start:it_start+z.size] # Since the size of z may have changed, we need to truncate t accordingly
                 else:
                     f[f'tracks/{i_tr:d}/z'] = z
                 f[f'tracks/{i_tr:d}/ux'] = ux


### PR DESCRIPTION
In `converters.py`, the `tracksfromOPMD` function has an argument `z_is_xi`. If set to true, the function tries to add `z+c*t`, in line 105.

However, sometimes the z array is split according to whether its entries are valid, in `split_tracks_by_nan`. If any entries are invalid, then `z` has a different dimension to `t`. This commit adds a line to split `t` according to the size of `z`. 