### PR TITLE
Fix tracksFromOPMD Nit_min/Nit_max codepath

### DIFF
--- a/synchrad/converters.py
+++ b/synchrad/converters.py
@@ -62,13 +62,6 @@ def tracksFromOPMD(ts, pt, ref_iteration,
     t = ts.t.copy()
 
     # Build the iteration window from a single combined boolean mask.
-    # The previous chained-filter form
-    #     iteration_ind = np.arange(iterations.size)
-    #     iteration_ind = iteration_ind[iterations>=Nit_min]   # shrinks
-    #     iteration_ind = iteration_ind[iterations<=Nit_max]   # IndexError
-    # IndexError'd whenever both Nit_min and Nit_max were given: the
-    # second filter applied a full-length boolean mask to the already
-    # shrunken iteration_ind.
     iteration_mask = np.ones(iterations.size, dtype=bool)
     if Nit_min is not None:
         iteration_mask &= (iterations >= Nit_min)

--- a/synchrad/converters.py
+++ b/synchrad/converters.py
@@ -60,13 +60,21 @@ def tracksFromOPMD(ts, pt, ref_iteration,
 
     iterations = ts.iterations.copy()
     t = ts.t.copy()
-    iteration_ind = np.arange(iterations.size, dtype=np.int64)
 
+    # Build the iteration window from a single combined boolean mask.
+    # The previous chained-filter form
+    #     iteration_ind = np.arange(iterations.size)
+    #     iteration_ind = iteration_ind[iterations>=Nit_min]   # shrinks
+    #     iteration_ind = iteration_ind[iterations<=Nit_max]   # IndexError
+    # IndexError'd whenever both Nit_min and Nit_max were given: the
+    # second filter applied a full-length boolean mask to the already
+    # shrunken iteration_ind.
+    iteration_mask = np.ones(iterations.size, dtype=bool)
     if Nit_min is not None:
-        iteration_ind = iteration_ind[iterations>=Nit_min]
-
+        iteration_mask &= (iterations >= Nit_min)
     if Nit_max is not None:
-        iteration_ind = iteration_ind[iterations<=Nit_max]
+        iteration_mask &= (iterations <= Nit_max)
+    iteration_ind = np.where(iteration_mask)[0]
 
     iterations = iterations[iteration_ind]
     t = t[iteration_ind]
@@ -91,9 +99,13 @@ def tracksFromOPMD(ts, pt, ref_iteration,
     for var in var_list:
         TC[var] = np.array(TC[var], order='F').T
 
-    # temporal patch to select iterations -- should go ts.iterate
-    #for var in var_list:
-    #    TC[var] = TC[var][:, iteration_ind]
+    # `ts.iterate` above walks the FULL `ts.iterations`, so each TC[var]
+    # comes back with shape (N_selected, ts.iterations.size).  When an
+    # Nit_min/Nit_max window was requested, slice down to that window so
+    # downstream `it_start` indexing matches `iterations`/`t` above.
+    if Nit_min is not None or Nit_max is not None:
+        for var in var_list:
+            TC[var] = TC[var][:, iteration_ind]
 
     i_tr = 0
     it_start_global = np.inf


### PR DESCRIPTION
## Summary

Two interlocked bugs make the `Nit_min`/`Nit_max` arguments of
`tracksFromOPMD` unusable in the current `dev` HEAD (7e0d82e):

1. **Boolean-mask shape mismatch.**  The chained-filter form

   ```python
   iteration_ind = np.arange(iterations.size)
   iteration_ind = iteration_ind[iterations >= Nit_min]   # shrinks
   iteration_ind = iteration_ind[iterations <= Nit_max]   # IndexError
   ```

   raises `IndexError` whenever both bounds are set: the second filter
   applies a full-length boolean mask to the already-shrunken
   `iteration_ind`.  Replaced with a single combined boolean mask,
   which is also clearer.

2. **Trajectory arrays never sliced to the window.**  The slice that
   should follow the iteration filter sits commented out a few lines
   below (`# temporal patch to select iterations`):

   ```python
   #for var in var_list:
   #    TC[var] = TC[var][:, iteration_ind]
   ```

   `ts.iterate` walks the full `ts.iterations` regardless of the
   filter, so each `TC[var]` returns with shape `(N_selected,
   ts.iterations.size)` — but the windowed `iterations` / `t` arrays
   built just above suggest the smaller series.  Downstream
   `it_start` indexing inside `split_track_by_nans` then references
   the wrong column count and produces wrong-length tracks (or
   IndexError's on `t[it_start:it_start+z.size]` when `z_is_xi=True`).

   Restored the slice, gated on either bound being set so the
   no-window code path stays untouched, and added a comment explaining
   why it has to live there (after the list-of-lists → ndarray
   conversion).

## Context

Hit while integrating SynchRad into a hybrid LWFA→PWFA betatron
pipeline at ELI-NP (FBPIC's `BackTransformedParticleDiagnostic` →
`tracksFromOPMD` → `SynchRad.calculate_spectrum`).  Was working
around bug (1) downstream by mutating `ts.iterations` / `ts.t` before
the call; this PR makes the upstream API match its docstring so the
workaround can be removed.

## Test plan

- [x] **Syntax check** — `python -c "import ast; ast.parse(open('synchrad/converters.py').read())"` ⇒ ok
- [x] **End-to-end equivalence on a real FBPIC extract.**  Ran the
  same iteration window twice over a 3001-snapshot
  `BackTransformedParticleDiagnostic` tree (FBPIC pure-N₂ run, ~1.94M
  candidate particles, sequential sampling of 200):
    - **Mode A** — stock @ 7e0d82e + the local `ts.iterations`-mutation
      workaround (`Nit_min/Nit_max` *not* passed to `tracksFromOPMD`).
    - **Mode B** — PR-patched `tracksFromOPMD` with `Nit_min=2950,
      Nit_max=3000` passed directly, `ts.iterations` left untouched.

  Result (200 common track IDs out of 200 written by each):

  | check | A | B | Δ |
  |---|---|---|---|
  | N_particles | 200 | 200 | 0 |
  | it_range | [0, 51] | [0, 51] | match |
  | cdt | 6.023597e-06 | 6.023597e-06 | 0.00e+00 |
  | shape match (20-track sample) | — | — | 20/20 |
  | it_start match (20-track sample) | — | — | 20/20 |
  | max \|Δ\| per field — x, y, z, ux, uy, uz, w | — | — | 0.000000e+00 (all) |

  PR-patched output is **bit-exact** with the workaround's output.
- [x] **No-window code path** (`Nit_min=Nit_max=None`) — the new gate
  at line 109 (`if Nit_min is not None or Nit_max is not None:`) only
  fires when at least one bound is set, so the no-window path is
  untouched.

Verification script + raw output available on request.